### PR TITLE
Update containerd (Nov 29, 2017)

### DIFF
--- a/aufs.go
+++ b/aufs.go
@@ -431,3 +431,7 @@ func useDirperm() bool {
 	})
 	return dirpermEnabled
 }
+
+func (o *snapshotter) Close() error {
+	return o.ms.Close()
+}

--- a/aufs_test.go
+++ b/aufs_test.go
@@ -31,6 +31,6 @@ func TestAufs(t *testing.T) {
 		if err != nil {
 			return nil, nil, err
 		}
-		return s, nil, nil
+		return s, s.Close, nil
 	})
 }


### PR DESCRIPTION
For containerd/containerd#1728

Signed-off-by: Akihiro Suda <suda.akihiro@lab.ntt.co.jp>