### PR TITLE
README: update badges to show GHA status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # aufs snapshotter
 
-[![Build Status](https://travis-ci.org/containerd/aufs.svg?branch=master)](https://travis-ci.org/containerd/aufs)
+[![PkgGoDev](https://pkg.go.dev/badge/github.com/containerd/aufs)](https://pkg.go.dev/github.com/containerd/aufs)
+[![Build Status](https://github.com/containerd/aufs/workflows/CI/badge.svg)](https://github.com/containerd/aufs/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/containerd/aufs/branch/master/graph/badge.svg)](https://codecov.io/gh/containerd/aufs)
+[![Go Report Card](https://goreportcard.com/badge/github.com/containerd/aufs)](https://goreportcard.com/report/github.com/containerd/aufs)
 
 
 AUFS implementation of the snapshot interface for containerd.


### PR DESCRIPTION
Overlooked this when reviewing 2e3cd2d2ed4d87d38d1de75b4ad3c246fef4c1a4
Also adds badges for pkg.go.dev and Go Report Card.
