### PR TITLE
Update GitHub actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
 
   checks:
     name: Project Checks
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
 
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
 
@@ -24,7 +24,7 @@ jobs:
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/aufs
           fetch-depth: 25
@@ -41,10 +41,10 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.x]
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/aufs
 
@@ -56,20 +56,21 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48.0
+          version: v1.50.1
           working-directory: src/github.com/containerd/aufs
 
   tests:
     name: Tests
-    runs-on: ubuntu-18.04
+    # Canonical has dropped AUFS support starting Ubuntu 21.04.
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src/github.com/containerd/aufs
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18.x
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,14 @@
 linters:
   enable:
-    - structcheck
-    - varcheck
     - staticcheck
     - unconvert
     - gofmt
     - goimports
-    - golint
     - ineffassign
     - vet
     - unused
     - misspell
+    - revive
   disable:
     - errcheck
 


### PR DESCRIPTION
Update actions runner OS image from Ubuntu 18.04 to Ubuntu 20.04. Update actions/checkout and actions/setup-go packages from v2 to v3. Update golangci/golangci-lint package from v1.48.0 to v1.50.1.

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>